### PR TITLE
Fix cache bug, Refactor messages handler and service

### DIFF
--- a/internal/api/app_config/app_config.go
+++ b/internal/api/app_config/app_config.go
@@ -35,5 +35,10 @@ func (a *appConfig) GetMsgHandler() handlers.MsgHandler {
 			dbmanager.CASSANDRA_KEYSPACE,
 			dbmanager.MSGS_TABLE,
 		),
+		services.NewUserService(
+			dbmanager.CassandraSession,
+			dbmanager.CASSANDRA_KEYSPACE,
+			dbmanager.USERS_TABLE,
+		),
 	)
 }

--- a/internal/api/cache/cache.go
+++ b/internal/api/cache/cache.go
@@ -3,13 +3,12 @@ package cache
 import (
 	"context"
 	"log"
-	"time"
 
 	"github.com/go-redis/redis/v8"
 )
 
 const (
-	DURATION = 30 * time.Second
+	DURATION = 0 //30 * time.Second
 	DB       = 1
 )
 


### PR DESCRIPTION
- Fix bug for cached messages to be sorted correctly by timestamp. Previously when new message is sent by user, we were getting cache, add the new message, set to cache again. But we ignored the timestamp sorting/order while doing that operation.

- Relocate the update cache logic to the message service instead of handler.

- Let the message handler have access to a user service instance to use it for checking user existence and other user related operations.

- Allow cache to be permanent, to be invalidated only by code logic.

- Update appConfig to create the messages handler appropriately and accordingly.

Fixes: #5fac3a3, #75dd434, #4c239d4