### PR TITLE
Fix message create timestamp

### DIFF
--- a/internal/api/cache/cache.go
+++ b/internal/api/cache/cache.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	DURATION = 0 //30 * time.Second
-	DB       = 1
+	DURATION         = 0 //30 * time.Second
+	DB               = 1
+	CACHE_KEY_SUFFIX = "-messages"
 )
 
 var (

--- a/internal/services/message.go
+++ b/internal/services/message.go
@@ -36,7 +36,7 @@ func NewMessageService(db *gocql.Session, keyspace, tableName string) *messageSe
 
 func (s *messageService) CreateMessage(message *models.Message) error {
 	message.ID = gocql.TimeUUID()
-	message.Timestamp = time.Now()
+	message.Timestamp = time.Now().UTC()
 
 	query := fmt.Sprintf(
 		`INSERT INTO %s.%s


### PR DESCRIPTION
- Respect timezone differences. Store the message with timestamp as UTC, then both sender and recipient can have their own timezone stored with their profile info. Thus, we can adjust the messages retrieval endpoint to convert the time of each message for their user who fetches them as per their current stored timezone on their profile.

- Refactor the `CACHE_KEY_SUFFIX` to be located in the appropriate package, so other packages can grab it when needed to be centralized and prevent code smells.

- Reflect relocation of `CACHE_KEY_SUFFIX` to cache package on `MessageHandler` methods.

- Create/Introduce `MessageHandler` interface to be used for dependency injection and to promote testability, and maintainability.

Fixes: #5fac3a3